### PR TITLE
Add Occurify

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Framework.
 - [ChilliCream GraphQL Platform](https://github.com/ChilliCream/hotchocolate) - GraphQL server for .NET.
 - [Puppeteer Sharp](https://github.com/hardkoded/puppeteer-sharp) - A .NET port of the official Node.JS Puppeteer API.
 - [Noda Time](https://github.com/nodatime/nodatime) - An alternative date and time API for .NET.
+- [Occurify](https://github.com/Occurify/Occurify) - A powerful and intuitive .NET library for defining, filtering, transforming, and scheduling instant and period timelines.
 - [Sieve](https://github.com/Biarity/Sieve) - Clean & extensible Sorting, Filtering, and Pagination for ASP.NET Core.
 - [FluentScheduler](https://github.com/fluentscheduler/FluentScheduler) - About
 Automated job scheduler with fluent interface for the .NET platform.


### PR DESCRIPTION
Issue: https://github.com/JessicaBarclay/awesome-csharp/issues/17

[Occurify](https://github.com/Occurify/Occurify) - A powerful and intuitive .NET library for defining, filtering, transforming, and scheduling instant and period timelines.

Wasn't sure about ordering, so I placed it underneath NodaTime, as I plan on making Occurify NodaTime compatible.